### PR TITLE
The date picker defaults to today’s date on first page load

### DIFF
--- a/script.mjs
+++ b/script.mjs
@@ -6,6 +6,17 @@
 
 import { getUserIDs } from "./common.mjs";
 
+const datePicker = document.getElementById("datepicker");
+
+const getDateInAString = function (date) {
+  const currentDate = date ? new Date(date) : new Date();
+  const year = currentDate.getFullYear();
+  const month = String(currentDate.getMonth() + 1).padStart(2, "0");
+  const day = String(currentDate.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
 window.onload = function () {
   const users = getUserIDs();
+  datePicker.value = getDateInAString();
 };


### PR DESCRIPTION
I made this changes to pass the requirement:

> The date picker must default to today’s date on first page load