### PR TITLE
add formatDate utility to convert dates to readable string

### DIFF
--- a/common.mjs
+++ b/common.mjs
@@ -1,3 +1,21 @@
 export function getUserIDs() {
   return ["1", "2", "3", "4", "5"];
 }
+
+export function formatDate(date) {
+  const d = new Date(date);
+  const day = d.getDate();
+  const month = d.toLocaleString('default', { month: 'long' });
+  const year = d.getFullYear();
+
+  const suffix =
+    day % 10 === 1 && day !== 11
+      ? 'st'
+      : day % 10 === 2 && day !== 12
+      ? 'nd'
+      : day % 10 === 3 && day !== 13
+      ? 'rd'
+      : 'th';
+
+  return `${day}${suffix} ${month} ${year}`;
+}


### PR DESCRIPTION
this improves how dates are shown to users by using a natural format with correct day suffixes (e.g., 1st, 2nd, 3rd, 4th...). This is helpful for reports, reminders, or any user-facing content.
How it works:

Converts the input into a Date object

Extracts the day, full month name, and year

Adds the correct English ordinal suffix to the day (st, nd, rd, th)

Returns a string like "21st March 2025"